### PR TITLE
Support for uploading of large files

### DIFF
--- a/src/onedrivesdk/helpers/file_slice.py
+++ b/src/onedrivesdk/helpers/file_slice.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+'''
+The MIT License (MIT)
+
+Copyright (c) 2015 Wiktor Niesiobędzki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+'''
+
+import io
+import os
+
+class FileSlice(io.RawIOBase):
+    '''
+    This class represents a window over a file handle. It will allow only access
+    and read of bytes above start and no further than end/length bytes
+    '''
+    def __init__(self, handle, start, end=None, length=None):
+        '''
+        Creates new instance of FileSlice on file-like object handle. It behaves
+        like normal file object, but only allow reading of bytes above start and
+        no further than end/lenght byte
+
+        Args:
+            handle (file-like object): file handle object to create a view over.
+                File should be open in binary mode
+            start (int): start byte number, makring the first byte that can be
+                read from FileSlice
+            end (int): Optional. Last byte of the file that can be read.
+            length (int): Optional. Number of the bytes, starting from the
+                start, that can be read from FileSlice
+
+            One of end or length must be provided
+        '''
+        assert end or length, "You need to provide one of end or length parameter"
+        assert not (end and length), "You need to proivde only one parameter: end or length, not both"
+        self._handle = handle
+        self._start = start
+        if end:
+            self._end = end
+        else:
+            self._end = start + length
+        self.seek(0)
+
+    @property
+    def _bytes_left(self):
+        current_pos = self._handle.tell()
+        return self._end - current_pos
+
+    def close(self):
+        # do nothing, someone else might want to process this file
+        return
+
+    @property
+    def closed(self):
+        return self._handle.closed
+
+    def fileno(self):
+        return self._handle.fileno()
+
+    def flush(self):
+        return self._handle.flush()
+
+    def len(self):
+        # this is provided for requests, so it will properly recognize the size of the file
+        return self._bytes_left
+
+    def __len__(self):
+        # this is provided for requests, so it will properly recognize the size of the file
+        return self.len()
+
+    def isatty(self):
+        return self._handle.isatty()
+
+    def readable(self):
+        return self._handle.readable()
+
+    def read(self, size=-1):
+        if size == -1:
+            read_size = self._bytes_left
+        else:
+            read_size = min(size, self._bytes_left)
+        return self._handle.read(read_size)
+
+    def readall(self):
+        return self._handle.read(self._bytes_left)
+
+    def readinto(self, b):
+        if len(b) > self._bytes_left:
+            r = self._handle.read(self._bytes_left)
+            b[:len(r)] = r
+            return len(r)
+        return self._handle.readinto(b)
+
+    def readline(self, size=-1):
+        return self._handle.readline(max(size, self._bytes_left))
+
+    def readlines(self, hint=-1):
+        return self._handle.readlines(max(hint, self._bytes_left))
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        if whence == io.SEEK_SET:
+            desired_pos = self._start + offset
+        if whence == io.SEEK_CUR:
+            desired_pos = self._handle.tell() + offset
+        if whence == io.SEEK_END:
+            desired_pos = self._end + offset
+
+        if desired_pos < self._start:
+            raise ValueError("Seeking before the file slice")
+        if offset > self._end:
+            raise ValueError("Seekeing past the end of file slice")
+
+        ret = self._handle.seek(desired_pos, io.SEEK_SET)
+        if ret:
+            return ret - self._start
+        else:
+            return ret
+
+    def seekable(self):
+        return self._handle.seekable()
+
+    def tell(self):
+        return self._handle.tell() - self._start
+
+    def truncate(self, size=None):
+        raise OSError("Operation not supported")
+
+    def writable(self):
+        return False
+
+    def write(self, b):
+        return OSError("Operation not supported")
+
+    def writelines(self, lines):
+        raise OSError("Operation not supported")
+
+def test():
+    import os
+    import math
+    with open(__file__, "rb") as f:
+        file_len = os.stat(__file__).st_size
+        for start_pos in range(int(math.ceil(file_len / 100))):
+            part = FileSlice(f, start_pos*100, length=100)
+            print("============= Part Start ==============")
+            print(part.read().decode('utf-8'))
+            print("============= Part End ================")
+
+if __name__ == '__main__':
+    test()

--- a/src/onedrivesdk/model/uploaded_fragment.py
+++ b/src/onedrivesdk/model/uploaded_fragment.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*- 
+'''
+# The MIT License (MIT)
+# Copyright (c) 2015 Wiktor Niesiobedzki
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+# 
+'''
+
+from __future__ import unicode_literals
+from ..one_drive_object_base import OneDriveObjectBase
+
+
+class UploadedFragment(OneDriveObjectBase):
+
+    def __init__(self, prop_dict={}):
+        self._prop_dict = prop_dict
+
+    @property
+    def expiration_date_time(self):
+        """Gets and sets the expirationDateTime
+        
+        Returns: 
+            datetime:
+                The expirationDateTime
+        """
+        if "expirationDateTime" in self._prop_dict:
+            return datetime.strptime(self._prop_dict["expirationDateTime"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f")
+        else:
+            return None
+
+    @expiration_date_time.setter
+    def expiration_date_time(self, val):
+        self._prop_dict["expirationDateTime"] = val.isoformat()+"Z"
+
+    @property
+    def next_expected_ranges(self):
+        """Gets and sets the nextExpectedRanges
+        
+        Returns: 
+            str:
+                The nextExpectedRanges
+        """
+        if "nextExpectedRanges" in self._prop_dict:
+            return self._prop_dict["nextExpectedRanges"]
+        else:
+            return None
+
+    @next_expected_ranges.setter
+    def next_expected_ranges(self, val):
+        self._prop_dict["nextExpectedRanges"] = val
+
+    @property
+    def id(self):
+        """Gets and sets id
+
+        Returns:
+            str: item id
+        """
+        return self._prop_dict.get("id")
+
+    @id.setter
+    def id(self, val):
+        self._prop_dict["id"] = val
+    
+    @property
+    def name(self):
+        """Gets and sets file name
+
+        Returns:
+            str: file name
+        """
+        return self._prop_dict.get("name")
+
+    @name.setter
+    def name(self, val):
+        self._prop_dict["name"] = val
+
+    @property
+    def size(self):
+        """Gets and sets file size
+
+        Returns:
+            str: file size
+        """
+        return self._prop_dict.get("size")
+
+    @size.setter
+    def size(self, val):
+        self._prop_dict["size"] = val
+
+    @property
+    def file(self):
+        """Gets and sets file dictionary
+
+        Returns:
+            dict: dictionary of fils
+        """
+        self._prop_dict.get("file")
+
+    @file.setter
+    def file(self, val):
+        self._prop_dict["file"] = val

--- a/src/onedrivesdk/request_base.py
+++ b/src/onedrivesdk/request_base.py
@@ -113,7 +113,7 @@ class RequestBase(object):
         elif isinstance(option, QueryOption):
             self._query_options[option.key] = option.value
 
-    def send(self, content=None, path=None):
+    def send(self, content=None, path=None, data=None):
         """Send the request using the client specified
         at request initialization
 
@@ -122,6 +122,8 @@ class RequestBase(object):
                 that will be sent
             path (str): Defaults to None, the local path of the file which
                 will be sent
+            data (file object): Defaults to none, the file object of the
+                file which will be sent
 
         Returns:
             :class:`HttpResponse<onedrivesdk.http_response.HttpResponse>`:
@@ -141,6 +143,12 @@ class RequestBase(object):
                 self._headers,
                 self.request_url,
                 path=path)
+        elif data:
+            response = self._client.http_provider.send(
+                self.method,
+                self._headers,
+                self.request_url,
+                data=data)
         else:
             content_dict = None
 

--- a/src/python2/request/item_create_session.py
+++ b/src/python2/request/item_create_session.py
@@ -68,7 +68,8 @@ class ItemCreateSessionRequestBuilder(RequestBuilderBase):
         super(ItemCreateSessionRequestBuilder, self).__init__(request_url, client)
         self._method_options = {}
 
-        self._method_options["item"] = item._prop_dict
+        if item:
+            self._method_options["item"] = item._prop_dict
 
     def request(self, options=None):
         """Builds the request for the ItemCreateSession
@@ -81,7 +82,7 @@ class ItemCreateSessionRequestBuilder(RequestBuilderBase):
             :class:`ItemCreateSessionRequest<onedrivesdk.request.item_create_session.ItemCreateSessionRequest>`:
                 The request
         """
-        req = ItemCreateSessionRequest(self._request_url, self._client, options, item=self._method_options["item"])
+        req = ItemCreateSessionRequest(self._request_url, self._client, options, item=self._method_options.get("item"))
         return req
 
     def post(self):

--- a/src/python2/request/item_upload_fragment.py
+++ b/src/python2/request/item_upload_fragment.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*- 
+'''
+# Copyright (c) 2015 Microsoft Corporation
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+# 
+#  This file was generated and any changes will be overwritten.
+'''
+
+
+from ..model.uploaded_fragment import UploadedFragment
+from ..request_base import RequestBase
+from ..request_builder_base import RequestBuilderBase
+from ..options import *
+from ..helpers.file_slice import FileSlice
+import json
+import asyncio
+import os
+
+
+class ItemUploadFragment(RequestBase):
+
+    def __init__(self, request_url, client, options, file_handle):
+        super(ItemUploadFragment, self).__init__(request_url, client, options)
+        self.method = "PUT"
+        self._file_handle = file_handle
+
+    def post(self):
+        """Sends the POST request
+        
+        Returns: 
+            :class:`UploadedFragment<onedrivesdk.model.upload_session.UploadedFragment>`:
+                The resulting entity from the operation
+        """
+        entity = UploadedFragment(json.loads(self.send(data=self._file_handle).content))
+        return entity
+
+    @asyncio.coroutine
+    def post_async(self):
+        """Sends the POST request using an asyncio coroutine
+
+        Yields:
+            :class:`UploadedFragment<onedrivesdk.model.upload_session.UploadedFragment>`:
+                The resulting entity from the operation
+        """
+        future = self._client._loop.run_in_executor(None,
+                                                    self.post)
+        entity = yield from future
+        return entity
+
+
+class ItemUploadFragmentBuilder(RequestBuilderBase):
+    def __init__(self, request_url, client, content_local_path):
+        super(ItemUploadFragmentBuilder, self).__init__(request_url, client)
+        self._method_options = {}
+        self._file_handle = open(content_local_path, "rb")
+        self._total_length = os.stat(content_local_path).st_size
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self._file_handle.close()
+
+    def request(self, begin, length, options=None):
+        """Builds the request for the ItemUploadFragment
+        
+        Args:
+            options (list of :class:`Option<onedrivesdk.options.Option>`):
+                Default to None, list of options to include in the request
+
+        Returns: 
+            :class:`ItemUploadFragment<onedrivesdk.request.item_upload_fragment.ItemUploadFragment>`:
+                The request
+        """
+        opts = None
+        if not (options is None or len(options) == 0):
+            opts = options.copy()
+        else:
+            opts = []
+
+        self.content_type = "application/octet-stream"
+
+        opts.append(HeaderOption("Content-Range", "bytes %d-%d/%d" % (begin, begin + length - 1, self._total_length)))
+        opts.append(HeaderOption("Content-Length", length))
+
+        file_slice = FileSlice(self._file_handle, begin, length=length)
+        req = ItemUploadFragment(self._request_url, self._client, opts, file_slice)
+        return req
+
+    def post(self, begin, length, options=None):
+        """Sends the POST request
+        
+        Returns:
+            :class:`UploadedFragment<onedrivesdk.model.uploaded_fragment.UploadedFragment>`:
+            The resulting UploadSession from the operation
+        """
+        return self.request(begin, length, options).post()
+
+    @asyncio.coroutine
+    def post_async(self, begin, length, options=None):
+        """Sends the POST request using an asyncio coroutine
+        
+        Yields:
+            :class:`UploadedFragment<onedrivesdk.model.uploaded_fragment.UploadedFragment>`:
+                The resulting UploadSession from the operation
+        """
+        entity = yield from self.request(begin, length, options).post_async()
+        return entity
+

--- a/src/python3/request/item_content_request.py
+++ b/src/python3/request/item_content_request.py
@@ -26,8 +26,12 @@
 from ..request_base import RequestBase
 from ..request_builder_base import RequestBuilderBase
 from ..model.item import Item
+from ..model.chunked_upload_session_descriptor import ChunkedUploadSessionDescriptor
+from .item_upload_fragment import ItemUploadFragmentBuilder
 import json
 import asyncio
+import os
+import math
 
 
 class ItemContentRequest(RequestBase):
@@ -55,10 +59,21 @@ class ItemContentRequest(RequestBase):
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The created Item.
         """
-        self.method = "PUT"
-        entity_response = self.send(path=content_local_path)
-        entity = Item(json.loads(entity_response.content))
-        return entity
+        file_size = os.stat(content_local_path).st_size
+        if file_size <= 100 * 1024 * 1024:
+            self.method = "PUT"
+            entity_response = self.send(path=content_local_path)
+            entity = Item(json.loads(entity_response.content))
+            return entity
+        else:
+            # resumable upload needed for larger files
+            session = ItemRequestBuilder(self._request, self._client).create_session()
+            __PART_SIZE = 60 * 1024 * 1024
+
+            with ItemUploadFragmentBuilder(session.uploadUrl, self._client, content_local_path) as upload_builder:
+                for i in range(math.ceil(file_size / __PART_SIZE)):
+                    resp = upload_builder.post(i * __PART_SIZE, __PART_SIZE)
+            return resp
 
     @asyncio.coroutine
     def upload_async(self, content_local_path):

--- a/src/python3/request/item_create_session.py
+++ b/src/python3/request/item_create_session.py
@@ -81,7 +81,8 @@ class ItemCreateSessionRequestBuilder(RequestBuilderBase):
         super(ItemCreateSessionRequestBuilder, self).__init__(request_url, client)
         self._method_options = {}
 
-        self._method_options["item"] = item._prop_dict
+        if item:
+            self._method_options["item"] = item._prop_dict
 
     def request(self, options=None):
         """Builds the request for the ItemCreateSession
@@ -94,7 +95,7 @@ class ItemCreateSessionRequestBuilder(RequestBuilderBase):
             :class:`ItemCreateSessionRequest<onedrivesdk.request.item_create_session.ItemCreateSessionRequest>`:
                 The request
         """
-        req = ItemCreateSessionRequest(self._request_url, self._client, options, item=self._method_options["item"])
+        req = ItemCreateSessionRequest(self._request_url, self._client, options, item=self._method_options.get("item"))
         return req
 
     def post(self):

--- a/src/python3/request/item_request_builder.py
+++ b/src/python3/request/item_request_builder.py
@@ -33,7 +33,12 @@ from ..request.item_all_photos import ItemAllPhotosRequestBuilder
 from ..request.item_delta import ItemDeltaRequestBuilder
 from ..request.item_search import ItemSearchRequestBuilder
 from ..request.item_content_request import ItemContentRequestBuilder
+from ..request.item_upload_fragment import ItemUploadFragmentBuilder
+from ..error import OneDriveError
 import asyncio
+import math
+import os
+import time
 
 
 class ItemRequestBuilder(RequestBuilderBase):
@@ -132,7 +137,33 @@ class ItemRequestBuilder(RequestBuilderBase):
         Returns: 
             The created entity.
         """
-        return self.content.request().upload(local_path)
+        file_size = os.stat(local_path).st_size
+        if file_size <= 100 * 1024 * 1024:
+            return self.content.request().upload(local_path)
+        else:
+            # resumable upload needed for larger files
+            session = self.create_session().post()
+            __PART_SIZE = 10 * 1024 * 1024 # recommended file size. Should be multiple of 320 * 1024
+
+            with ItemUploadFragmentBuilder(session.upload_url, self._client, local_path) as upload_builder:
+                for i in range(math.ceil(file_size / __PART_SIZE)):
+                    length = min(__PART_SIZE, file_size - i  * __PART_SIZE)
+                    tries = 0
+                    while True:
+                        try:
+                            tries += 1
+                            resp = upload_builder.post(i * __PART_SIZE, length)
+                        except OneDriveError as exc:
+                            if exc.status_code in (500, 502, 503, 504) and tries < 5:
+                                time.sleep(5)
+                                continue
+                            elif exc.status_code == 401:
+                                self._client.auth_provider.refresh_token()
+                                continue
+                            else:
+                                raise exc
+                        break
+            return resp
 
     @asyncio.coroutine
     def upload_async(self, local_path):

--- a/src/python3/request/item_upload_fragment.py
+++ b/src/python3/request/item_upload_fragment.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*- 
+'''
+# Copyright (c) 2015 Microsoft Corporation
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+# 
+#  This file was generated and any changes will be overwritten.
+'''
+
+
+from ..model.uploaded_fragment import UploadedFragment
+from ..request_base import RequestBase
+from ..request_builder_base import RequestBuilderBase
+from ..options import *
+from ..helpers.file_slice import FileSlice
+import json
+import asyncio
+import os
+
+
+class ItemUploadFragment(RequestBase):
+
+    def __init__(self, request_url, client, options, file_handle):
+        super(ItemUploadFragment, self).__init__(request_url, client, options)
+        self.method = "PUT"
+        self._file_handle = file_handle
+
+    def post(self):
+        """Sends the POST request
+        
+        Returns: 
+            :class:`UploadedFragment<onedrivesdk.model.upload_session.UploadedFragment>`:
+                The resulting entity from the operation
+        """
+        entity = UploadedFragment(json.loads(self.send(data=self._file_handle).content))
+        return entity
+
+    @asyncio.coroutine
+    def post_async(self):
+        """Sends the POST request using an asyncio coroutine
+
+        Yields:
+            :class:`UploadedFragment<onedrivesdk.model.upload_session.UploadedFragment>`:
+                The resulting entity from the operation
+        """
+        future = self._client._loop.run_in_executor(None,
+                                                    self.post)
+        entity = yield from future
+        return entity
+
+
+class ItemUploadFragmentBuilder(RequestBuilderBase):
+    def __init__(self, request_url, client, content_local_path):
+        super(ItemUploadFragmentBuilder, self).__init__(request_url, client)
+        self._method_options = {}
+        self._file_handle = open(content_local_path, "rb")
+        self._total_length = os.stat(content_local_path).st_size
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self._file_handle.close()
+
+    def request(self, begin, length, options=None):
+        """Builds the request for the ItemUploadFragment
+        
+        Args:
+            options (list of :class:`Option<onedrivesdk.options.Option>`):
+                Default to None, list of options to include in the request
+
+        Returns: 
+            :class:`ItemUploadFragment<onedrivesdk.request.item_upload_fragment.ItemUploadFragment>`:
+                The request
+        """
+        opts = None
+        if not (options is None or len(options) == 0):
+            opts = options.copy()
+        else:
+            opts = []
+
+        self.content_type = "application/octet-stream"
+
+        opts.append(HeaderOption("Content-Range", "bytes %d-%d/%d" % (begin, begin + length - 1, self._total_length)))
+        opts.append(HeaderOption("Content-Length", length))
+
+        file_slice = FileSlice(self._file_handle, begin, length=length)
+        req = ItemUploadFragment(self._request_url, self._client, opts, file_slice)
+        return req
+
+    def post(self, begin, length, options=None):
+        """Sends the POST request
+        
+        Returns:
+            :class:`UploadedFragment<onedrivesdk.model.uploaded_fragment.UploadedFragment>`:
+            The resulting UploadSession from the operation
+        """
+        return self.request(begin, length, options).post()
+
+    @asyncio.coroutine
+    def post_async(self, begin, length, options=None):
+        """Sends the POST request using an asyncio coroutine
+        
+        Yields:
+            :class:`UploadedFragment<onedrivesdk.model.uploaded_fragment.UploadedFragment>`:
+                The resulting UploadSession from the operation
+        """
+        entity = yield from self.request(begin, length, options).post_async()
+        return entity
+


### PR DESCRIPTION
 Support for uploading large files to OneDrive.
- Added FileSlice class that provides a chunked view over file object
- Added UploadedFragment class that represents chunk upload response
- Added ability to send file like objects in RequestBase.send(...)
- Added support in ItemRequestBuilder.upload(...) to adapt it's behaviour based on file size. If file size is larger than 100MB, an upload session is used to upload files in 10MB chunks
