### PR TITLE
Timestamp format customization

### DIFF
--- a/src/onedrivesdk/extensions/datetime_helper.py
+++ b/src/onedrivesdk/extensions/datetime_helper.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+DEFAULT_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+def datetime_from_string(string, format=None):
+    """Proxy for `datetime.strptime`. Gets customizable format from
+    global variable `DEFAULT_DATETIME_FORMAT` if `format` is None.
+    """
+    if format is None:
+        format = DEFAULT_DATETIME_FORMAT
+    return datetime.strptime(string, format)

--- a/src/onedrivesdk/model/file_system_info.py
+++ b/src/onedrivesdk/model/file_system_info.py
@@ -24,7 +24,7 @@
 '''
 
 from __future__ import unicode_literals
-from datetime import datetime
+from ..extensions.datetime_helper import datetime_from_string
 from ..one_drive_object_base import OneDriveObjectBase
 
 
@@ -42,7 +42,7 @@ class FileSystemInfo(OneDriveObjectBase):
                 The createdDateTime
         """
         if "createdDateTime" in self._prop_dict:
-            return datetime.strptime(self._prop_dict["createdDateTime"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f")
+            return datetime_from_string(self._prop_dict["createdDateTime"])
         else:
             return None
 
@@ -59,7 +59,7 @@ class FileSystemInfo(OneDriveObjectBase):
                 The lastModifiedDateTime
         """
         if "lastModifiedDateTime" in self._prop_dict:
-            return datetime.strptime(self._prop_dict["lastModifiedDateTime"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f")
+            return datetime_from_string(self._prop_dict["lastModifiedDateTime"])
         else:
             return None
 

--- a/src/onedrivesdk/model/item.py
+++ b/src/onedrivesdk/model/item.py
@@ -40,7 +40,7 @@ from ..model.special_folder import SpecialFolder
 from ..model.video import Video
 from ..model.permission import Permission
 from ..model.thumbnail_set import ThumbnailSet
-from datetime import datetime
+from ..extensions.datetime_helper import datetime_from_string
 from ..one_drive_object_base import OneDriveObjectBase
 
 
@@ -81,7 +81,7 @@ class Item(OneDriveObjectBase):
                 The createdDateTime
         """
         if "createdDateTime" in self._prop_dict:
-            return datetime.strptime(self._prop_dict["createdDateTime"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f")
+            return datetime_from_string(self._prop_dict["createdDateTime"])
         else:
             return None
 
@@ -193,7 +193,7 @@ class Item(OneDriveObjectBase):
                 The lastModifiedDateTime
         """
         if "lastModifiedDateTime" in self._prop_dict:
-            return datetime.strptime(self._prop_dict["lastModifiedDateTime"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f")
+            return datetime_from_string(self._prop_dict["lastModifiedDateTime"])
         else:
             return None
 

--- a/src/onedrivesdk/model/photo.py
+++ b/src/onedrivesdk/model/photo.py
@@ -24,7 +24,7 @@
 '''
 
 from __future__ import unicode_literals
-from datetime import datetime
+from ..extensions.datetime_helper import datetime_from_string
 from ..one_drive_object_base import OneDriveObjectBase
 
 
@@ -144,7 +144,7 @@ class Photo(OneDriveObjectBase):
                 The takenDateTime
         """
         if "takenDateTime" in self._prop_dict:
-            return datetime.strptime(self._prop_dict["takenDateTime"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f")
+            return datetime_from_string(self._prop_dict["takenDateTime"])
         else:
             return None
 

--- a/src/onedrivesdk/model/upload_session.py
+++ b/src/onedrivesdk/model/upload_session.py
@@ -24,7 +24,7 @@
 '''
 
 from __future__ import unicode_literals
-from datetime import datetime
+from ..extensions.datetime_helper import datetime_from_string
 from ..one_drive_object_base import OneDriveObjectBase
 
 
@@ -59,7 +59,7 @@ class UploadSession(OneDriveObjectBase):
                 The expirationDateTime
         """
         if "expirationDateTime" in self._prop_dict:
-            return datetime.strptime(self._prop_dict["expirationDateTime"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f")
+            return datetime_from_string(self._prop_dict["expirationDateTime"])
         else:
             return None
 


### PR DESCRIPTION
This commit adds a possibility to customize the format fed to `datetime.strptime`.
At the moment, OneDrive for Business responds with timestamp in format `'%Y-%m-%dT%H:%M:%SZ'` (note the absense of `%f` part in the end), and it results in crashes on access to any timestamp-related fields.
With the format stored in a module one can monkey-patch it like this:

``` python
import onedrivesdk.extensions.datetime_helper as dh
dh.DEFAULT_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
```

It is the easiest solution came to my mind.
