### PR TITLE
Fix the code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ from onedrivesdk.helpers import GetAuthCodeServer
 
 redirect_uri = 'http://localhost:8080/'
 client_secret = 'your_app_secret'
+scopes=['wl.signin', 'wl.offline_access', 'onedrive.readwrite']
 
 client = onedrivesdk.get_default_client(
-    client_id='your_client_id',
+    client_id='your_client_id', scopes=scopes)
 
 auth_url = client.auth_provider.get_auth_url(redirect_uri)
 


### PR DESCRIPTION
`Traceback (most recent call last):
  File "OneDriveTest.py", line 9, in <module>
    client_id='XXXXXXXXXXXXXXXX)
TypeError: get_default_client() missing 1 required positional argument: 'scopes'`

For this sample, I think `onedrivesdk.get_default_client()` need the argument `scopes=['wl.signin', 'wl.offline_access', 'onedrive.readwrite']`
