### PR TITLE
Fixes the type of the Content-Length header option

### DIFF
--- a/src/onedrivesdk/version_bridge/fragment_upload.py
+++ b/src/onedrivesdk/version_bridge/fragment_upload.py
@@ -102,7 +102,7 @@ class ItemUploadFragmentBuilder(RequestBuilderBase):
         self.content_type = "application/octet-stream"
 
         opts.append(HeaderOption("Content-Range", "bytes %d-%d/%d" % (begin, begin + length - 1, self._total_length)))
-        opts.append(HeaderOption("Content-Length", length))
+        opts.append(HeaderOption("Content-Length", str(length)))
 
         file_slice = FileSlice(self._file_handle, begin, length=length)
         req = ItemUploadFragment(self._request_url, self._client, opts, file_slice)


### PR DESCRIPTION
Fixes the type of the Content-Length header option. It was a variable of the type int, but should be a string.

According with the standards, the type of all the http header option variables must be a string. If this is not the case, the header will throw an exception in the request header sanity checks in Python3.
