### PR TITLE
Adding import Item removed in old commit and never re-added back.

### DIFF
--- a/examples/CommandLineFileExplorer.py
+++ b/examples/CommandLineFileExplorer.py
@@ -153,8 +153,12 @@ def list_changes(client, item_id, token):
 
 
 def get_parent_id(client, item_id):
-    id = client.item(id=item_id).get().parent_reference.id
-    return id
+    try:
+        id = client.item(id=item_id).get().parent_reference.id
+        return id
+    except AttributeError:
+        print("Error: There's no parent to this folder.")
+        return "root"
 
 if __name__ == "__main__":
     main()

--- a/src/python2/request/children_collection.py
+++ b/src/python2/request/children_collection.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 from ..collection_base import CollectionRequestBase, CollectionResponseBase
 from ..request_builder_base import RequestBuilderBase
 from ..model.children_collection_page import ChildrenCollectionPage
+from ..model.item import Item
 import json
 
 class ChildrenCollectionRequest(CollectionRequestBase):


### PR DESCRIPTION
Adding import Item removed in 143c0cf8d7ae7c86d13c9009e4b463e7edbf76b7 and forgotten when re-adding add() in f585ca3477c9ddf1567874a66c0c333fca531b02. 

Also fixing get_parent_id method so it doesn't break when user is on root folder. This one is obviously optional, but I thought it could be a nice improvement.