### PR TITLE
Set allow_reuse_address for GetAuthCodeServer helper class

### DIFF
--- a/src/onedrivesdk/helpers/GetAuthCodeServer.py
+++ b/src/onedrivesdk/helpers/GetAuthCodeServer.py
@@ -73,6 +73,7 @@ def get_auth_code(auth_url, redirect_uri):
 class GetAuthCodeServer(HTTPServer, object):
 
     def __init__(self, server_address, stop_event, RequestHandlerClass):
+        self.allow_reuse_address = True
         HTTPServer.__init__(self, server_address, RequestHandlerClass)
         self._stop_event = stop_event
         self.auth_code = None


### PR DESCRIPTION
Currently the GetAuthCodeServer socket lingers, this change helps prevent occurences of `socket.error: [Errno 98] Address already in use` errors such as:

```
File "onedrivesdk/helpers/GetAuthCodeServer.py", line 62, in get_auth_code
    GetAuthCodeRequestHandler)
  File "onedrivesdk/helpers/GetAuthCodeServer.py", line 78, in __init__
    HTTPServer.__init__(self, server_address, RequestHandlerClass)
  File "/usr/lib/python2.7/SocketServer.py", line 417, in __init__
    self.server_bind()
  File "/usr/lib/python2.7/SocketServer.py", line 431, in server_bind
    self.socket.bind(self.server_address)
  File "/usr/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 98] Address already in use
```