### PR TITLE
Add auto save session

### DIFF
--- a/src/onedrivesdk/model/item.py
+++ b/src/onedrivesdk/model/item.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 '''
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-# 
+#
 #  This file was generated and any changes will be overwritten.
 '''
 
@@ -38,8 +38,8 @@ class Item(OneDriveObjectBase):
     def created_by(self):
         """
         Gets and sets the createdBy
-        
-        Returns: 
+
+        Returns:
             :class:`IdentitySet<onedrivesdk.model.identity_set.IdentitySet>`:
                 The createdBy
         """
@@ -60,7 +60,7 @@ class Item(OneDriveObjectBase):
     def created_date_time(self):
         """
         Gets and sets the createdDateTime
-        
+
         Returns:
             datetime:
                 The createdDateTime
@@ -81,7 +81,7 @@ class Item(OneDriveObjectBase):
     def c_tag(self):
         """
         Gets and sets the cTag
-        
+
         Returns:
             str:
                 The cTag
@@ -99,7 +99,7 @@ class Item(OneDriveObjectBase):
     def description(self):
         """
         Gets and sets the description
-        
+
         Returns:
             str:
                 The description
@@ -117,7 +117,7 @@ class Item(OneDriveObjectBase):
     def e_tag(self):
         """
         Gets and sets the eTag
-        
+
         Returns:
             str:
                 The eTag
@@ -135,7 +135,7 @@ class Item(OneDriveObjectBase):
     def id(self):
         """
         Gets and sets the id
-        
+
         Returns:
             str:
                 The id
@@ -153,8 +153,8 @@ class Item(OneDriveObjectBase):
     def last_modified_by(self):
         """
         Gets and sets the lastModifiedBy
-        
-        Returns: 
+
+        Returns:
             :class:`IdentitySet<onedrivesdk.model.identity_set.IdentitySet>`:
                 The lastModifiedBy
         """
@@ -175,7 +175,7 @@ class Item(OneDriveObjectBase):
     def last_modified_date_time(self):
         """
         Gets and sets the lastModifiedDateTime
-        
+
         Returns:
             datetime:
                 The lastModifiedDateTime
@@ -196,7 +196,7 @@ class Item(OneDriveObjectBase):
     def name(self):
         """
         Gets and sets the name
-        
+
         Returns:
             str:
                 The name
@@ -214,8 +214,8 @@ class Item(OneDriveObjectBase):
     def parent_reference(self):
         """
         Gets and sets the parentReference
-        
-        Returns: 
+
+        Returns:
             :class:`ItemReference<onedrivesdk.model.item_reference.ItemReference>`:
                 The parentReference
         """
@@ -236,7 +236,7 @@ class Item(OneDriveObjectBase):
     def size(self):
         """
         Gets and sets the size
-        
+
         Returns:
             int:
                 The size
@@ -254,7 +254,7 @@ class Item(OneDriveObjectBase):
     def web_url(self):
         """
         Gets and sets the webUrl
-        
+
         Returns:
             str:
                 The webUrl
@@ -269,11 +269,22 @@ class Item(OneDriveObjectBase):
         self._prop_dict["webUrl"] = val
 
     @property
+    def download_url(self):
+        if "@content.downloadUrl" in self._prop_dict:
+            return self._prop_dict["@content.downloadUrl"]
+        else:
+            return None
+
+    @download_url.setter
+    def download_url(self, val):
+        self._prop_dict["@content.downloadUrl"] = val
+
+    @property
     def audio(self):
         """
         Gets and sets the audio
-        
-        Returns: 
+
+        Returns:
             :class:`Audio<onedrivesdk.model.audio.Audio>`:
                 The audio
         """
@@ -294,8 +305,8 @@ class Item(OneDriveObjectBase):
     def deleted(self):
         """
         Gets and sets the deleted
-        
-        Returns: 
+
+        Returns:
             :class:`Deleted<onedrivesdk.model.deleted.Deleted>`:
                 The deleted
         """
@@ -316,8 +327,8 @@ class Item(OneDriveObjectBase):
     def file(self):
         """
         Gets and sets the file
-        
-        Returns: 
+
+        Returns:
             :class:`File<onedrivesdk.model.file.File>`:
                 The file
         """
@@ -338,8 +349,8 @@ class Item(OneDriveObjectBase):
     def file_system_info(self):
         """
         Gets and sets the fileSystemInfo
-        
-        Returns: 
+
+        Returns:
             :class:`FileSystemInfo<onedrivesdk.model.file_system_info.FileSystemInfo>`:
                 The fileSystemInfo
         """
@@ -360,8 +371,8 @@ class Item(OneDriveObjectBase):
     def folder(self):
         """
         Gets and sets the folder
-        
-        Returns: 
+
+        Returns:
             :class:`Folder<onedrivesdk.model.folder.Folder>`:
                 The folder
         """
@@ -382,8 +393,8 @@ class Item(OneDriveObjectBase):
     def image(self):
         """
         Gets and sets the image
-        
-        Returns: 
+
+        Returns:
             :class:`Image<onedrivesdk.model.image.Image>`:
                 The image
         """
@@ -404,8 +415,8 @@ class Item(OneDriveObjectBase):
     def location(self):
         """
         Gets and sets the location
-        
-        Returns: 
+
+        Returns:
             :class:`Location<onedrivesdk.model.location.Location>`:
                 The location
         """
@@ -426,8 +437,8 @@ class Item(OneDriveObjectBase):
     def open_with(self):
         """
         Gets and sets the openWith
-        
-        Returns: 
+
+        Returns:
             :class:`OpenWithSet<onedrivesdk.model.open_with_set.OpenWithSet>`:
                 The openWith
         """
@@ -448,8 +459,8 @@ class Item(OneDriveObjectBase):
     def photo(self):
         """
         Gets and sets the photo
-        
-        Returns: 
+
+        Returns:
             :class:`Photo<onedrivesdk.model.photo.Photo>`:
                 The photo
         """
@@ -470,8 +481,8 @@ class Item(OneDriveObjectBase):
     def remote_item(self):
         """
         Gets and sets the remoteItem
-        
-        Returns: 
+
+        Returns:
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The remoteItem
         """
@@ -492,8 +503,8 @@ class Item(OneDriveObjectBase):
     def search_result(self):
         """
         Gets and sets the searchResult
-        
-        Returns: 
+
+        Returns:
             :class:`SearchResult<onedrivesdk.model.search_result.SearchResult>`:
                 The searchResult
         """
@@ -514,8 +525,8 @@ class Item(OneDriveObjectBase):
     def shared(self):
         """
         Gets and sets the shared
-        
-        Returns: 
+
+        Returns:
             :class:`Shared<onedrivesdk.model.shared.Shared>`:
                 The shared
         """
@@ -536,8 +547,8 @@ class Item(OneDriveObjectBase):
     def special_folder(self):
         """
         Gets and sets the specialFolder
-        
-        Returns: 
+
+        Returns:
             :class:`SpecialFolder<onedrivesdk.model.special_folder.SpecialFolder>`:
                 The specialFolder
         """
@@ -558,8 +569,8 @@ class Item(OneDriveObjectBase):
     def video(self):
         """
         Gets and sets the video
-        
-        Returns: 
+
+        Returns:
             :class:`Video<onedrivesdk.model.video.Video>`:
                 The video
         """
@@ -579,8 +590,8 @@ class Item(OneDriveObjectBase):
     @property
     def permissions(self):
         """Gets and sets the permissions
-        
-        Returns: 
+
+        Returns:
             :class:`PermissionsCollectionPage<onedrivesdk.request.permissions_collection.PermissionsCollectionPage>`:
                 The permissions
         """
@@ -592,8 +603,8 @@ class Item(OneDriveObjectBase):
     @property
     def subscriptions(self):
         """Gets and sets the subscriptions
-        
-        Returns: 
+
+        Returns:
             :class:`SubscriptionsCollectionPage<onedrivesdk.request.subscriptions_collection.SubscriptionsCollectionPage>`:
                 The subscriptions
         """
@@ -605,8 +616,8 @@ class Item(OneDriveObjectBase):
     @property
     def versions(self):
         """Gets and sets the versions
-        
-        Returns: 
+
+        Returns:
             :class:`VersionsCollectionPage<onedrivesdk.request.versions_collection.VersionsCollectionPage>`:
                 The versions
         """
@@ -618,8 +629,8 @@ class Item(OneDriveObjectBase):
     @property
     def children(self):
         """Gets and sets the children
-        
-        Returns: 
+
+        Returns:
             :class:`ChildrenCollectionPage<onedrivesdk.request.children_collection.ChildrenCollectionPage>`:
                 The children
         """
@@ -631,8 +642,8 @@ class Item(OneDriveObjectBase):
     @property
     def tags(self):
         """Gets and sets the tags
-        
-        Returns: 
+
+        Returns:
             :class:`TagsCollectionPage<onedrivesdk.request.tags_collection.TagsCollectionPage>`:
                 The tags
         """
@@ -644,8 +655,8 @@ class Item(OneDriveObjectBase):
     @property
     def thumbnails(self):
         """Gets and sets the thumbnails
-        
-        Returns: 
+
+        Returns:
             :class:`ThumbnailsCollectionPage<onedrivesdk.request.thumbnails_collection.ThumbnailsCollectionPage>`:
                 The thumbnails
         """

--- a/src/onedrivesdk/session.py
+++ b/src/onedrivesdk/session.py
@@ -37,7 +37,8 @@ class Session(SessionBase):
                  auth_server_url,
                  redirect_uri,
                  refresh_token=None,
-                 client_secret=None):
+                 client_secret=None,
+                 user_id=None):
         self.token_type = token_type
         self._expires_at = time() + int(expires_in)
         self.scope = scope_string.split(" ")
@@ -47,6 +48,7 @@ class Session(SessionBase):
         self.redirect_uri = redirect_uri
         self.refresh_token = refresh_token
         self.client_secret = client_secret
+        self.user_id = user_id
 
     def is_expired(self):
         """Whether or not the session has expired
@@ -70,7 +72,7 @@ class Session(SessionBase):
         both save_session() and load_session() should be overwritten using
         the client system's correct mechanism (keychain, database, etc.).
         Remember, the access_token should be treated the same as a password.
-        
+
         Args:
             save_session_kwargs (dicr): To be used by implementation
             of save_session, however save_session wants to use them. The
@@ -80,7 +82,7 @@ class Session(SessionBase):
         path = "session.pickle"
         if "path" in save_session_kwargs:
             path = save_session_kwargs["path"]
-        
+
         with open(path, "wb") as session_file:
             import pickle
             # pickle.HIGHEST_PROTOCOL is binary format. Good perf.
@@ -94,7 +96,7 @@ class Session(SessionBase):
         both save_session() and load_session() should be overwritten using
         the client system's correct mechanism (keychain, database, etc.).
         Remember, the access_token should be treated the same as a password.
-        
+
         Args:
             load_session_kwargs (dict): To be used by implementation
             of load_session, however load_session wants to use them. The
@@ -107,7 +109,7 @@ class Session(SessionBase):
         path = "session.pickle"
         if "path" in load_session_kwargs:
             path = load_session_kwargs["path"]
-        
+
         with open(path, "rb") as session_file:
             import pickle
             return pickle.load(session_file)

--- a/src/onedrivesdk/session_base.py
+++ b/src/onedrivesdk/session_base.py
@@ -36,9 +36,10 @@ class SessionBase(object):
                  auth_server_url,
                  redirect_uri,
                  refresh_token=None,
-                 client_secret=None):
+                 client_secret=None,
+                 user_id=None):
         pass
-    
+
     @abc.abstractmethod
     def is_expired(self):
         pass
@@ -46,11 +47,11 @@ class SessionBase(object):
     @abc.abstractmethod
     def refresh_session(self, expires_in, scope_string, access_token, refresh_token):
         pass
-    
+
     @abc.abstractmethod
     def save_session(self, **save_session_kwargs):
         pass
-    
+
     @abc.abstractmethod
     def load_session(**load_session_kwargs):
         pass


### PR DESCRIPTION
Does not manually save the session every time now.

At first time, save session when authenticated.
```python
client.auth_provider.save_session(path='/tmp/1drv.session')
```

Then just load the session. It will auto refresh token if session expired, and save session again.
```python
scopes = ['wl.signin', 'wl.offline_access', 'onedrive.readwrite']
http_provider = onedrivesdk.HttpProvider()
auth_provider = onedrivesdk.AuthProvider(http_provider, scopes=scopes)
client = onedrivesdk.OneDriveClient(api_base_url, auth_provider, http_provider)

client.auth_provider.load_session(path='/tmp/1drv.session')
```

The other commit is add an attribute `download_url` in **Item** model.