### PR TITLE
ResourceDiscoveryRequest should support proxies argument.

### DIFF
--- a/src/onedrivesdk/helpers/resource_discovery.py
+++ b/src/onedrivesdk/helpers/resource_discovery.py
@@ -3,9 +3,10 @@ import json
 
 
 class ResourceDiscoveryRequest(object):
-    def __init__(self):
+    def __init__(self, proxies=None):
         self._method = 'GET'
         self._discovery_service_url = 'https://api.office.com/discovery/v2.0/me/services'
+        self._proxies = proxies
 
     def get_service_info(self, access_token):
         """Send request to discovery service. Return ServiceInfo
@@ -22,7 +23,7 @@ class ResourceDiscoveryRequest(object):
                 capability = 'MyFiles' and service_api_version = 'v2.0'
         """
         headers = {'Authorization': 'Bearer ' + access_token}
-        response = json.loads(requests.get(self._discovery_service_url, headers=headers).text)
+        response = json.loads(requests.get(self._discovery_service_url, headers=headers, proxies=self._proxies).text)
         service_info_list = [ServiceInfo(x) for x in response['value']]
         trimmed_service_info_list = [si for si in service_info_list
                                      if si.capability == 'MyFiles' and si.service_api_version == 'v2.0']


### PR DESCRIPTION
ResourceDiscoveryRequest does not support requests through proxy.

I added `proxies` argument to `ResourceDiscoveryRequest.__init__`, so that `requests.get` can be called with `proxies`.

Regards,
Murase