### PR TITLE
upload: support both content and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ client = onedrivesdk.OneDriveClient(service_info.service_resource_id + '/_api/v2
 ### Upload an Item
 
 ```python
-returned_item = client.item(drive='me', id='root').children['newfile.txt'].upload('./path_to_file.txt')
+returned_item = client.item(drive='me', id='root').children['newfile.txt'].upload(path='./path_to_file.txt')
 ```
 
 ### Download an Item

--- a/examples/CommandLineFileExplorer.py
+++ b/examples/CommandLineFileExplorer.py
@@ -128,7 +128,7 @@ def download(client, item_id):
 def upload(client, item_id):
     directory = input("Enter upload file directory (can be relative): ")
     name = input("Enter file name with extension: ")
-    client.item(id=item_id).children[name].upload(directory)
+    client.item(id=item_id).children[name].upload(path=directory)
 
 
 def delete(client, item_id):

--- a/src/python2/request/item_content_request.py
+++ b/src/python2/request/item_content_request.py
@@ -43,19 +43,24 @@ class ItemContentRequest(RequestBase):
         """
         super(ItemContentRequest, self).__init__(request_url, client, options)
 
-    def upload(self, content_local_path):
+    def upload(self, content=None, path=None):
         """Uploads the file using PUT
         
         Args:
-            content_local_path (str):
+            path (str):
                 The path to the local file to upload.
+            content(bytes)
+                The cotent of the file
 
         Returns: 
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The created Item.
         """
         self.method = "PUT"
-        entity_response = self.send(path=content_local_path)
+        if content:
+            entity_response = self.send(content=content)
+        else path:
+            entity_response = self.send(path=path)
         entity = Item(json.loads(entity_response.content))
         return entity
 

--- a/src/python2/request/item_request_builder.py
+++ b/src/python2/request/item_request_builder.py
@@ -76,16 +76,16 @@ class ItemRequestBuilder(RequestBuilderBase):
         return self.request().update(item)
 
 
-    def upload(self, local_path):
+    def upload(self, path=None, content=None):
         """Uploads the file using PUT
         
         Args:
-            local_path (str): The path to the local file to upload.
-
+            path(str): The path to the local file to upload.
+            content(bytes): The content of file.
         Returns: 
             The created entity.
         """
-        return self.content.request().upload(local_path)
+        return self.content.request().upload(path=path, content=content)
 
 
     def download(self, local_path):

--- a/src/python3/request/item_content_request.py
+++ b/src/python3/request/item_content_request.py
@@ -44,19 +44,24 @@ class ItemContentRequest(RequestBase):
         """
         super(ItemContentRequest, self).__init__(request_url, client, options)
 
-    def upload(self, content_local_path):
+    def upload(self, content=None, path=None):
         """Uploads the file using PUT
         
         Args:
-            content_local_path (str):
+            path (str):
                 The path to the local file to upload.
+            content(bytes)
+                The cotent of the file
 
         Returns: 
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The created Item.
         """
         self.method = "PUT"
-        entity_response = self.send(path=content_local_path)
+        if content:
+            entity_response = self.send(content=content)
+        else path:
+            entity_response = self.send(path=path)
         entity = Item(json.loads(entity_response.content))
         return entity
 

--- a/src/python3/request/item_request_builder.py
+++ b/src/python3/request/item_request_builder.py
@@ -105,16 +105,16 @@ class ItemRequestBuilder(RequestBuilderBase):
         entity = yield from self.request().update_async(item)
         return entity
 
-    def upload(self, local_path):
+    def upload(self, path=None, content=None):
         """Uploads the file using PUT
         
         Args:
-            local_path (str): The path to the local file to upload.
-
+            path(str): The path to the local file to upload.
+            content(bytes): The content of file.
         Returns: 
             The created entity.
         """
-        return self.content.request().upload(local_path)
+        return self.content.request().upload(path=path, content=content)
 
     @asyncio.coroutine
     def upload_async(self, local_path):

--- a/testonedrivesdk/test_streams.py
+++ b/testonedrivesdk/test_streams.py
@@ -28,7 +28,7 @@ class TestStreams(unittest.TestCase):
         auth_provider = onedrivesdk.AuthProvider()
         client = onedrivesdk.OneDriveClient("onedriveurl/", http_provider, auth_provider)
 
-        response_item = client.drives["me"].items["root"].children["newFile.txt"].content.request().upload("./myPath/myFile.txt")
+        response_item = client.drives["me"].items["root"].children["newFile.txt"].content.request().upload(path="./myPath/myFile.txt")
 
         assert client.http_provider.send.call_args[1]["path"] == "./myPath/myFile.txt"
         assert client.http_provider.send.call_args[0][2] == "onedriveurl/drives/me/items/root/children/newFile.txt/content"


### PR DESCRIPTION
`upload()` use the method `send()`, which originally supports both put content and path. I don't know why `upload()` just always uses path at the end. It should also support given content. This patch add support for upload via content.