### PR TITLE
Addresses #115: Removes any unicode symbols from path

### DIFF
--- a/src/onedrivesdk/extensions/drive_request_builder_helper.py
+++ b/src/onedrivesdk/extensions/drive_request_builder_helper.py
@@ -28,16 +28,17 @@ from ..request.item_request_builder import ItemRequestBuilder
 
 def item_by_path(self, path):
     """Get an item by path in OneDrive
-    
+
     Args
         path (str): The path to the requested item
 
-    Returns: 
+    Returns:
         :class:`ItemRequestBuilder<onedrivesdk.requests.item_request_builder.ItemRequestBuilder>`:
             A request builder for an item given a path
     """
     #strip any leading '/'
-    path = str(path)[1:] if str(path)[0] == "/" else str(path)
+    path = str(path.encode("ascii", "ignore").decode("utf8"))[1:] if str(path.encode(
+        "ascii", "ignore").decode("utf8"))[0] == "/" else str(path.encode("ascii", "ignore").decode("utf8"))
     return ItemRequestBuilder(self.append_to_request_url("root:/"+str(path)+":"), self._client)
 
 DriveRequestBuilder.item_by_path = item_by_path


### PR DESCRIPTION
Considering unicode is not allowed in the path name. I have modified the function to encode path name first to `ascii` ignoring any unicodes, and then converts it back to plain unicode string.