### PR TITLE
Added UploadFromData Methods

### DIFF
--- a/src/onedrivesdk/auth_provider.py
+++ b/src/onedrivesdk/auth_provider.py
@@ -76,9 +76,6 @@ class AuthProvider(AuthProviderBase):
         self._auth_server_url = self.MSA_AUTH_SERVER_URL if auth_server_url is None else auth_server_url
         self._auth_token_url = self.MSA_AUTH_TOKEN_URL if auth_token_url is None else auth_token_url
 
-        if sys.version_info >= (3, 4, 0):
-            import asyncio
-            self._loop = loop if loop else asyncio.get_event_loop()
 
     @property
     def client_id(self):

--- a/src/python2/request/one_drive_client.py
+++ b/src/python2/request/one_drive_client.py
@@ -50,9 +50,6 @@ class OneDriveClient(object):
         self.auth_provider = auth_provider
         self.http_provider = http_provider
 
-        if sys.version_info >= (3, 4, 0):
-            import asyncio
-            self._loop = loop if loop else asyncio.get_event_loop()
 
     @property
     def auth_provider(self):

--- a/src/python3/request/item_content_request.py
+++ b/src/python3/request/item_content_request.py
@@ -59,7 +59,21 @@ class ItemContentRequest(RequestBase):
         entity_response = self.send(path=content_local_path)
         entity = Item(json.loads(entity_response.content))
         return entity
+    def uploadFromData(self, data):
+        """Uploads the file using PUT
+        
+        Args:
+            content_local_path (str):
+                The path to the local file to upload.
 
+        Returns: 
+            :class:`Item<onedrivesdk.model.item.Item>`:
+                The created Item.
+        """
+        self.method = "PUT"
+        entity_response = self.send(data=data)
+        entity = Item(json.loads(entity_response.content))
+        return entity
     @asyncio.coroutine
     def upload_async(self, content_local_path):
         """Uploads the file using PUT in async

--- a/src/python3/request/item_request_builder.py
+++ b/src/python3/request/item_request_builder.py
@@ -115,7 +115,16 @@ class ItemRequestBuilder(RequestBuilderBase):
             The created entity.
         """
         return self.content.request().upload(local_path)
+    def uploadFromData(self, data):
+        """Uploads the file using PUT
+        
+        Args:
+            local_path (str): The path to the local file to upload.
 
+        Returns: 
+            The created entity.
+        """
+        return self.content.request().uploadFromData(data)
     @asyncio.coroutine
     def upload_async(self, local_path):
         """Uploads the file using PUT in async

--- a/src/python3/request/one_drive_client.py
+++ b/src/python3/request/one_drive_client.py
@@ -50,9 +50,6 @@ class OneDriveClient(object):
         self.auth_provider = auth_provider
         self.http_provider = http_provider
 
-        if sys.version_info >= (3, 4, 0):
-            import asyncio
-            self._loop = loop if loop else asyncio.get_event_loop()
 
     @property
     def auth_provider(self):


### PR DESCRIPTION
Currently on Upload from Path is supported.
I have added method 
`uploadFromData`

That can be used like
`client.item(drive='me', id='root').children['abc.txt'].uploadFromData(data=file.read())`

Along with that get_event_loop() is removed because it generates problem with Django and Flask applications.