### PR TITLE
Make `onedrivesdk` compatible with Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,7 @@ implements `asyncio.ascompleted`, and execute it with
 ```python
 import asyncio
 
-@asyncio.coroutine
-def run_gets(client):
+async def run_gets(client):
     coroutines = [client.drive('me').request().get_async() for i in range(3)]
     for future in asyncio.as_completed(coroutines):
         drive = yield from future

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ import asyncio
 async def run_gets(client):
     coroutines = [client.drive('me').request().get_async() for i in range(3)]
     for future in asyncio.as_completed(coroutines):
-        drive = yield from future
+        drive = await future
         print(drive.id)
 
 loop = asyncio.get_event_loop()

--- a/src/onedrivesdk/version_bridge/async_operation_monitor_async.py
+++ b/src/onedrivesdk/version_bridge/async_operation_monitor_async.py
@@ -25,8 +25,7 @@ import asyncio
 from ..async_operation_monitor import AsyncOperationMonitor
 
 
-@asyncio.coroutine
-def poll_until_done_async(self):
+async def poll_until_done_async(self):
     """Yielding this method blocks until done polling for
     the result of the async operation is returned
 

--- a/src/onedrivesdk/version_bridge/async_operation_monitor_async.py
+++ b/src/onedrivesdk/version_bridge/async_operation_monitor_async.py
@@ -34,7 +34,7 @@ async def poll_until_done_async(self):
     """
     future = self._client._loop.run_in_executor(None,
                                                 self.poll_until_done)
-    item = yield from future
+    item = await future
     return item
 
 AsyncOperationMonitor.poll_until_done_async = poll_until_done_async

--- a/src/onedrivesdk/version_bridge/auth_provider_async.py
+++ b/src/onedrivesdk/version_bridge/auth_provider_async.py
@@ -25,8 +25,7 @@ import asyncio
 from ..auth_provider import AuthProvider
 
 
-@asyncio.coroutine
-def authenticate_async(self, code, redirect_uri, client_secret=None):
+async def authenticate_async(self, code, redirect_uri, client_secret=None):
     """Takes in a code string, gets the access token,
     and creates session property bag in async
 
@@ -46,8 +45,7 @@ def authenticate_async(self, code, redirect_uri, client_secret=None):
     yield from future
 
 
-@asyncio.coroutine
-def authenticate_request_async(self, request):
+async def authenticate_request_async(self, request):
     """Authenticate and append the required
     headers to the request in async
 
@@ -61,8 +59,7 @@ def authenticate_request_async(self, request):
     yield from future
 
 
-@asyncio.coroutine
-def refresh_token_async(self):
+async def refresh_token_async(self):
     """Refresh the token currently used by the session"""
     future = self._loop.run_in_executor(None,
                                         self.refresh_token)

--- a/src/onedrivesdk/version_bridge/auth_provider_async.py
+++ b/src/onedrivesdk/version_bridge/auth_provider_async.py
@@ -42,7 +42,7 @@ async def authenticate_async(self, code, redirect_uri, client_secret=None):
                                         code,
                                         redirect_uri,
                                         client_secret)
-    yield from future
+    await future
 
 
 async def authenticate_request_async(self, request):
@@ -56,14 +56,14 @@ async def authenticate_request_async(self, request):
     future = self._loop.run_in_executor(None,
                                         self.authenticate_request,
                                         request)
-    yield from future
+    await future
 
 
 async def refresh_token_async(self):
     """Refresh the token currently used by the session"""
     future = self._loop.run_in_executor(None,
                                         self.refresh_token)
-    yield from future
+    await future
 
 AuthProvider.authenticate_async = authenticate_async
 AuthProvider.authenticate_request_async = authenticate_async

--- a/src/onedrivesdk/version_bridge/fragment_upload.py
+++ b/src/onedrivesdk/version_bridge/fragment_upload.py
@@ -66,7 +66,7 @@ class ItemUploadFragment(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.post)
-        entity = yield from future
+        entity = await future
         return entity
 
 
@@ -126,7 +126,7 @@ class ItemUploadFragmentBuilder(RequestBuilderBase):
             :class:`UploadedFragment<onedrivesdk.model.uploaded_fragment.UploadedFragment>`:
                 The resulting UploadSession from the operation
         """
-        entity = yield from self.request(begin, length, options).post_async()
+        entity = await self.request(begin, length, options).post_async()
         return entity
 
 

--- a/src/onedrivesdk/version_bridge/fragment_upload.py
+++ b/src/onedrivesdk/version_bridge/fragment_upload.py
@@ -57,8 +57,7 @@ class ItemUploadFragment(RequestBase):
         entity = UploadSession(json.loads(self.send(data=self._file_handle).content))
         return entity
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
 
         Yields:
@@ -120,8 +119,7 @@ class ItemUploadFragmentBuilder(RequestBuilderBase):
         """
         return self.request(begin, length, options).post()
 
-    @asyncio.coroutine
-    def post_async(self, begin, length, options=None):
+    async def post_async(self, begin, length, options=None):
         """Sends the POST request using an asyncio coroutine
 
         Yields:

--- a/src/python3/request/children_collection.py
+++ b/src/python3/request/children_collection.py
@@ -44,8 +44,7 @@ class ChildrenCollectionRequest(CollectionRequestBase):
         entity = Item(json.loads(self.send(entity).content))
         return entity
 
-    @asyncio.coroutine
-    def add_async(self, entity):
+    async def add_async(self, entity):
         """Add a Item to the collection in async
         
         Args:
@@ -73,8 +72,7 @@ class ChildrenCollectionRequest(CollectionRequestBase):
         collection_response = ChildrenCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the ChildrenCollectionPage in async
 
         Yields: 
@@ -156,8 +154,7 @@ class ChildrenCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().add(entity)
 
-    @asyncio.coroutine
-    def add_async(self, entity):
+    async def add_async(self, entity):
         """Add a Item to the collection in async
         
         Args:
@@ -180,8 +177,7 @@ class ChildrenCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the ChildrenCollectionPage in async
 
         Yields: 

--- a/src/python3/request/children_collection.py
+++ b/src/python3/request/children_collection.py
@@ -58,7 +58,7 @@ class ChildrenCollectionRequest(CollectionRequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.add,
                                                     entity)
-        entity = yield from future
+        entity = await future
         return entity
 
     def get(self):
@@ -81,7 +81,7 @@ class ChildrenCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -165,7 +165,7 @@ class ChildrenCollectionRequestBuilder(RequestBuilderBase):
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The Item that you added, with additional data from OneDrive
         """
-        entity = yield from self.request().add_async(entity)
+        entity = await self.request().add_async(entity)
         return entity
 
     def get(self):
@@ -184,7 +184,7 @@ class ChildrenCollectionRequestBuilder(RequestBuilderBase):
             :class:`ChildrenCollectionPage<onedrivesdk.model.children_collection_page.ChildrenCollectionPage>`:
                 The ChildrenCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/drive_recent.py
+++ b/src/python3/request/drive_recent.py
@@ -29,8 +29,7 @@ class DriveRecentRequest(CollectionRequestBase):
         collection_response = ItemsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Sends the GET request using an asyncio coroutine
         
         Yields:
@@ -92,8 +91,7 @@ class DriveRecentRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Sends the GET request using an asyncio coroutine
         
         Yields:

--- a/src/python3/request/drive_recent.py
+++ b/src/python3/request/drive_recent.py
@@ -38,7 +38,7 @@ class DriveRecentRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_response = yield from future
+        collection_response = await future
         return collection_response
     
     @staticmethod
@@ -98,7 +98,7 @@ class DriveRecentRequestBuilder(RequestBuilderBase):
             :class:`ItemsCollectionResponse<onedrivesdk.request.items_collection.ItemsCollectionResponse>`:
                 The resulting ItemsCollectionResponse from the operation
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 from ..request.items_collection import ItemsCollectionResponse

--- a/src/python3/request/drive_request.py
+++ b/src/python3/request/drive_request.py
@@ -35,7 +35,7 @@ class DriveRequest(RequestBase):
         """Deletes the specified Drive."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified Drive.
@@ -58,7 +58,7 @@ class DriveRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, drive):
@@ -92,7 +92,7 @@ class DriveRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     drive)
-        entity = yield from future
+        entity = await future
         return entity
 
     def _initialize_collection_properties(self, value):

--- a/src/python3/request/drive_request.py
+++ b/src/python3/request/drive_request.py
@@ -31,8 +31,7 @@ class DriveRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Drive."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class DriveRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Drive in async.
 
         Yields:
@@ -80,8 +78,7 @@ class DriveRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, drive):
+    async def update_async(self, drive):
         """Updates the specified Drive in async
         
         Args:

--- a/src/python3/request/drive_request_builder.py
+++ b/src/python3/request/drive_request_builder.py
@@ -50,7 +50,7 @@ class DriveRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified Drive."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified Drive.
         
@@ -67,7 +67,7 @@ class DriveRequestBuilder(RequestBuilderBase):
             :class:`Drive<onedrivesdk.model.drive.Drive>`:
                 The Drive.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, drive):
         """Updates the specified Drive.
@@ -93,7 +93,7 @@ class DriveRequestBuilder(RequestBuilderBase):
             :class:`Drive<onedrivesdk.model.drive.Drive>`:
                 The updated Drive.
         """
-        entity = yield from self.request().update_async(drive)
+        entity = await self.request().update_async(drive)
         return entity
 
     @property

--- a/src/python3/request/drive_request_builder.py
+++ b/src/python3/request/drive_request_builder.py
@@ -48,8 +48,7 @@ class DriveRequestBuilder(RequestBuilderBase):
         """Deletes the specified Drive."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Drive."""
         yield from self.request().delete_async()
     def get(self):
@@ -61,8 +60,7 @@ class DriveRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Drive in async.
 
         Returns:
@@ -84,8 +82,7 @@ class DriveRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(drive)
 
-    @asyncio.coroutine
-    def update_async(self, drive):
+    async def update_async(self, drive):
         """Updates the specified Drive in async
         
         Args:

--- a/src/python3/request/drives_collection.py
+++ b/src/python3/request/drives_collection.py
@@ -38,8 +38,7 @@ class DrivesCollectionRequest(CollectionRequestBase):
         collection_response = DrivesCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the DrivesCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class DrivesCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the DrivesCollectionPage in async
 
         Yields: 

--- a/src/python3/request/drives_collection.py
+++ b/src/python3/request/drives_collection.py
@@ -47,7 +47,7 @@ class DrivesCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class DrivesCollectionRequestBuilder(RequestBuilderBase):
             :class:`DrivesCollectionPage<onedrivesdk.model.drives_collection_page.DrivesCollectionPage>`:
                 The DrivesCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/effective_roles_collection.py
+++ b/src/python3/request/effective_roles_collection.py
@@ -64,7 +64,7 @@ class EffectiveRolesCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
 class EffectiveRolesCollectionRequestBuilder(RequestBuilderBase):
@@ -119,7 +119,7 @@ class EffectiveRolesCollectionRequestBuilder(RequestBuilderBase):
             :class:`EffectiveRolesCollectionPage<onedrivesdk.request.effective_roles_collection.EffectiveRolesCollectionPage>`:
                 The EffectiveRolesCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/effective_roles_collection.py
+++ b/src/python3/request/effective_roles_collection.py
@@ -55,8 +55,7 @@ class EffectiveRolesCollectionRequest(CollectionRequestBase):
         collection_response = EffectiveRolesCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the EffectiveRolesCollectionPage in async
 
         Yields: 
@@ -113,8 +112,7 @@ class EffectiveRolesCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the EffectiveRolesCollectionPage in async
 
         Yields: 

--- a/src/python3/request/item_content_request.py
+++ b/src/python3/request/item_content_request.py
@@ -74,7 +74,7 @@ class ItemContentRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.put,
                                                     content_local_path)
-        entity = yield from future
+        entity = await future
         return entity
 
     def download(self, content_local_path):
@@ -97,7 +97,7 @@ class ItemContentRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.download,
                                                     content_local_path)
-        yield from future
+        await future
 
 class ItemContentRequestBuilder(RequestBuilderBase):
 

--- a/src/python3/request/item_content_request.py
+++ b/src/python3/request/item_content_request.py
@@ -60,8 +60,7 @@ class ItemContentRequest(RequestBase):
         entity = Item(json.loads(entity_response.content))
         return entity
 
-    @asyncio.coroutine
-    def upload_async(self, content_local_path):
+    async def upload_async(self, content_local_path):
         """Uploads the file using PUT in async
         
         Args:
@@ -87,8 +86,7 @@ class ItemContentRequest(RequestBase):
         """
         self.download_item(content_local_path)
 
-    @asyncio.coroutine
-    def download_async(self, content_local_path):
+    async def download_async(self, content_local_path):
         """
         Downloads the specified Item in async.
         

--- a/src/python3/request/item_copy.py
+++ b/src/python3/request/item_copy.py
@@ -74,7 +74,7 @@ class ItemCopyRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.post)
-        entity = yield from future
+        entity = await future
         return entity
 
 
@@ -117,6 +117,6 @@ class ItemCopyRequestBuilder(RequestBuilderBase):
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The resulting Item from the operation
         """
-        entity = yield from self.request().post_async()
+        entity = await self.request().post_async()
         return entity
 

--- a/src/python3/request/item_copy.py
+++ b/src/python3/request/item_copy.py
@@ -65,8 +65,7 @@ class ItemCopyRequest(RequestBase):
         entity = AsyncOperationMonitor(response.headers["Location"], self._client, None)
         return entity
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
 
         Yields:
@@ -111,8 +110,7 @@ class ItemCopyRequestBuilder(RequestBuilderBase):
         """
         return self.request().post()
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
         
         Yields:

--- a/src/python3/request/item_create_link.py
+++ b/src/python3/request/item_create_link.py
@@ -60,8 +60,7 @@ class ItemCreateLinkRequest(RequestBase):
         entity = Permission(json.loads(self.send(self.body_options).content))
         return entity
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
 
         Yields:
@@ -105,8 +104,7 @@ class ItemCreateLinkRequestBuilder(RequestBuilderBase):
         """
         return self.request().post()
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
         
         Yields:

--- a/src/python3/request/item_create_link.py
+++ b/src/python3/request/item_create_link.py
@@ -69,7 +69,7 @@ class ItemCreateLinkRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.post)
-        entity = yield from future
+        entity = await future
         return entity
 
 
@@ -111,6 +111,6 @@ class ItemCreateLinkRequestBuilder(RequestBuilderBase):
             :class:`Permission<onedrivesdk.model.permission.Permission>`:
                 The resulting Permission from the operation
         """
-        entity = yield from self.request().post_async()
+        entity = await self.request().post_async()
         return entity
 

--- a/src/python3/request/item_create_session.py
+++ b/src/python3/request/item_create_session.py
@@ -60,8 +60,7 @@ class ItemCreateSessionRequest(RequestBase):
         entity = UploadSession(json.loads(self.send(self.body_options).content))
         return entity
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
 
         Yields:
@@ -105,8 +104,7 @@ class ItemCreateSessionRequestBuilder(RequestBuilderBase):
         """
         return self.request().post()
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
         
         Yields:

--- a/src/python3/request/item_create_session.py
+++ b/src/python3/request/item_create_session.py
@@ -69,7 +69,7 @@ class ItemCreateSessionRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.post)
-        entity = yield from future
+        entity = await future
         return entity
 
 
@@ -111,6 +111,6 @@ class ItemCreateSessionRequestBuilder(RequestBuilderBase):
             :class:`UploadSession<onedrivesdk.model.upload_session.UploadSession>`:
                 The resulting UploadSession from the operation
         """
-        entity = yield from self.request().post_async()
+        entity = await self.request().post_async()
         return entity
 

--- a/src/python3/request/item_delta.py
+++ b/src/python3/request/item_delta.py
@@ -31,8 +31,7 @@ class ItemDeltaRequest(CollectionRequestBase):
         collection_response = ItemDeltaCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Sends the GET request using an asyncio coroutine
         
         Yields:
@@ -97,8 +96,7 @@ class ItemDeltaRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Sends the GET request using an asyncio coroutine
         
         Yields:

--- a/src/python3/request/item_delta.py
+++ b/src/python3/request/item_delta.py
@@ -40,7 +40,7 @@ class ItemDeltaRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_response = yield from future
+        collection_response = await future
         return collection_response
     
     @staticmethod
@@ -103,7 +103,7 @@ class ItemDeltaRequestBuilder(RequestBuilderBase):
             :class:`ItemDeltaCollectionResponse<onedrivesdk.request.item_delta_collection.ItemDeltaCollectionResponse>`:
                 The resulting ItemDeltaCollectionResponse from the operation
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 from ..request.item_delta_collection import ItemDeltaCollectionResponse

--- a/src/python3/request/item_invite.py
+++ b/src/python3/request/item_invite.py
@@ -50,8 +50,7 @@ class ItemInviteRequest(CollectionRequestBase):
         collection_response = ItemsCollectionResponse(json.loads(self.send(self.body_options).content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
 
         Yields:
@@ -107,8 +106,7 @@ class ItemInviteRequestBuilder(RequestBuilderBase):
         """
         return self.request().post()
 
-    @asyncio.coroutine
-    def post_async(self):
+    async def post_async(self):
         """Sends the POST request using an asyncio coroutine
         
         Yields:

--- a/src/python3/request/item_invite.py
+++ b/src/python3/request/item_invite.py
@@ -59,7 +59,7 @@ class ItemInviteRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.post)
-        collection_response = yield from future
+        collection_response = await future
         return collection_response
 
 
@@ -113,7 +113,7 @@ class ItemInviteRequestBuilder(RequestBuilderBase):
             :class:`ItemsCollectionResponse<onedrivesdk.request.items_collection.ItemsCollectionResponse>`:
                 The resulting ItemsCollectionResponse from the operation
         """
-        collection_page = yield from self.request().post_async()
+        collection_page = await self.request().post_async()
         return collection_page
 
 from ..request.items_collection import ItemsCollectionResponse

--- a/src/python3/request/item_request.py
+++ b/src/python3/request/item_request.py
@@ -31,8 +31,7 @@ class ItemRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Item."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class ItemRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Item in async.
 
         Yields:
@@ -80,8 +78,7 @@ class ItemRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, item):
+    async def update_async(self, item):
         """Updates the specified Item in async
         
         Args:

--- a/src/python3/request/item_request.py
+++ b/src/python3/request/item_request.py
@@ -35,7 +35,7 @@ class ItemRequest(RequestBase):
         """Deletes the specified Item."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified Item.
@@ -58,7 +58,7 @@ class ItemRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, item):
@@ -92,7 +92,7 @@ class ItemRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     item)
-        entity = yield from future
+        entity = await future
         return entity
 
     def _initialize_collection_properties(self, value):

--- a/src/python3/request/item_request_builder.py
+++ b/src/python3/request/item_request_builder.py
@@ -54,8 +54,7 @@ class ItemRequestBuilder(RequestBuilderBase):
         """Deletes the specified Item."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Item."""
         yield from self.request().delete_async()
     def get(self):
@@ -67,8 +66,7 @@ class ItemRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Item in async.
 
         Returns:
@@ -90,8 +88,7 @@ class ItemRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(item)
 
-    @asyncio.coroutine
-    def update_async(self, item):
+    async def update_async(self, item):
         """Updates the specified Item in async
         
         Args:
@@ -116,8 +113,7 @@ class ItemRequestBuilder(RequestBuilderBase):
         """
         return self.content.request().upload(local_path)
 
-    @asyncio.coroutine
-    def upload_async(self, local_path):
+    async def upload_async(self, local_path):
         """Uploads the file using PUT in async
         
         Args:
@@ -137,8 +133,7 @@ class ItemRequestBuilder(RequestBuilderBase):
         """
         return self.content.request().download(local_path)
 
-    @asyncio.coroutine
-    def download_async(self, local_path):
+    async def download_async(self, local_path):
         """Downloads the specified entity in async.
 
         Args:

--- a/src/python3/request/item_request_builder.py
+++ b/src/python3/request/item_request_builder.py
@@ -56,7 +56,7 @@ class ItemRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified Item."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified Item.
         
@@ -73,7 +73,7 @@ class ItemRequestBuilder(RequestBuilderBase):
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The Item.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, item):
         """Updates the specified Item.
@@ -99,7 +99,7 @@ class ItemRequestBuilder(RequestBuilderBase):
             :class:`Item<onedrivesdk.model.item.Item>`:
                 The updated Item.
         """
-        entity = yield from self.request().update_async(item)
+        entity = await self.request().update_async(item)
         return entity
 
     def upload(self, local_path):
@@ -121,7 +121,7 @@ class ItemRequestBuilder(RequestBuilderBase):
 
         Returns: The created entity.
         """
-        entity = yield from self.content.request().upload_async(local_path)
+        entity = await self.content.request().upload_async(local_path)
         return entity
 
     def download(self, local_path):
@@ -140,7 +140,7 @@ class ItemRequestBuilder(RequestBuilderBase):
             local_path (str): The path where the entity should be
                 downloaded to
         """
-        entity = yield from self.content.request().download_async(local_path)
+        entity = await self.content.request().download_async(local_path)
         return entity
 
     @property

--- a/src/python3/request/item_search.py
+++ b/src/python3/request/item_search.py
@@ -41,7 +41,7 @@ class ItemSearchRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_response = yield from future
+        collection_response = await future
         return collection_response
     
     @staticmethod
@@ -104,7 +104,7 @@ class ItemSearchRequestBuilder(RequestBuilderBase):
             :class:`ItemsCollectionResponse<onedrivesdk.request.items_collection.ItemsCollectionResponse>`:
                 The resulting ItemsCollectionResponse from the operation
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 from ..request.items_collection import ItemsCollectionResponse

--- a/src/python3/request/item_search.py
+++ b/src/python3/request/item_search.py
@@ -32,8 +32,7 @@ class ItemSearchRequest(CollectionRequestBase):
         collection_response = ItemsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Sends the GET request using an asyncio coroutine
         
         Yields:
@@ -98,8 +97,7 @@ class ItemSearchRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Sends the GET request using an asyncio coroutine
         
         Yields:

--- a/src/python3/request/items_collection.py
+++ b/src/python3/request/items_collection.py
@@ -38,8 +38,7 @@ class ItemsCollectionRequest(CollectionRequestBase):
         collection_response = ItemsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the ItemsCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class ItemsCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the ItemsCollectionPage in async
 
         Yields: 

--- a/src/python3/request/items_collection.py
+++ b/src/python3/request/items_collection.py
@@ -47,7 +47,7 @@ class ItemsCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class ItemsCollectionRequestBuilder(RequestBuilderBase):
             :class:`ItemsCollectionPage<onedrivesdk.model.items_collection_page.ItemsCollectionPage>`:
                 The ItemsCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/permission_request.py
+++ b/src/python3/request/permission_request.py
@@ -31,8 +31,7 @@ class PermissionRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Permission."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class PermissionRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Permission in async.
 
         Yields:
@@ -80,8 +78,7 @@ class PermissionRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, permission):
+    async def update_async(self, permission):
         """Updates the specified Permission in async
         
         Args:

--- a/src/python3/request/permission_request.py
+++ b/src/python3/request/permission_request.py
@@ -35,7 +35,7 @@ class PermissionRequest(RequestBase):
         """Deletes the specified Permission."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified Permission.
@@ -58,7 +58,7 @@ class PermissionRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, permission):
@@ -92,6 +92,6 @@ class PermissionRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     permission)
-        entity = yield from future
+        entity = await future
         return entity
 

--- a/src/python3/request/permission_request_builder.py
+++ b/src/python3/request/permission_request_builder.py
@@ -65,8 +65,7 @@ class PermissionRequestBuilder(RequestBuilderBase):
         """Deletes the specified Permission."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Permission."""
         yield from self.request().delete_async()
     def get(self):
@@ -78,8 +77,7 @@ class PermissionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Permission in async.
 
         Returns:
@@ -101,8 +99,7 @@ class PermissionRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(permission)
 
-    @asyncio.coroutine
-    def update_async(self, permission):
+    async def update_async(self, permission):
         """Updates the specified Permission in async
         
         Args:

--- a/src/python3/request/permission_request_builder.py
+++ b/src/python3/request/permission_request_builder.py
@@ -67,7 +67,7 @@ class PermissionRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified Permission."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified Permission.
         
@@ -84,7 +84,7 @@ class PermissionRequestBuilder(RequestBuilderBase):
             :class:`Permission<onedrivesdk.model.permission.Permission>`:
                 The Permission.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, permission):
         """Updates the specified Permission.
@@ -110,5 +110,5 @@ class PermissionRequestBuilder(RequestBuilderBase):
             :class:`Permission<onedrivesdk.model.permission.Permission>`:
                 The updated Permission.
         """
-        entity = yield from self.request().update_async(permission)
+        entity = await self.request().update_async(permission)
         return entity

--- a/src/python3/request/permissions_collection.py
+++ b/src/python3/request/permissions_collection.py
@@ -38,8 +38,7 @@ class PermissionsCollectionRequest(CollectionRequestBase):
         collection_response = PermissionsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the PermissionsCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class PermissionsCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the PermissionsCollectionPage in async
 
         Yields: 

--- a/src/python3/request/permissions_collection.py
+++ b/src/python3/request/permissions_collection.py
@@ -47,7 +47,7 @@ class PermissionsCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class PermissionsCollectionRequestBuilder(RequestBuilderBase):
             :class:`PermissionsCollectionPage<onedrivesdk.model.permissions_collection_page.PermissionsCollectionPage>`:
                 The PermissionsCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/share_request.py
+++ b/src/python3/request/share_request.py
@@ -31,8 +31,7 @@ class ShareRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Share."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class ShareRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Share in async.
 
         Yields:
@@ -80,8 +78,7 @@ class ShareRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, share):
+    async def update_async(self, share):
         """Updates the specified Share in async
         
         Args:

--- a/src/python3/request/share_request.py
+++ b/src/python3/request/share_request.py
@@ -35,7 +35,7 @@ class ShareRequest(RequestBase):
         """Deletes the specified Share."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified Share.
@@ -58,7 +58,7 @@ class ShareRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, share):
@@ -92,7 +92,7 @@ class ShareRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     share)
-        entity = yield from future
+        entity = await future
         return entity
 
     def _initialize_collection_properties(self, value):

--- a/src/python3/request/share_request_builder.py
+++ b/src/python3/request/share_request_builder.py
@@ -67,7 +67,7 @@ class ShareRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified Share."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified Share.
         
@@ -84,7 +84,7 @@ class ShareRequestBuilder(RequestBuilderBase):
             :class:`Share<onedrivesdk.model.share.Share>`:
                 The Share.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, share):
         """Updates the specified Share.
@@ -110,7 +110,7 @@ class ShareRequestBuilder(RequestBuilderBase):
             :class:`Share<onedrivesdk.model.share.Share>`:
                 The updated Share.
         """
-        entity = yield from self.request().update_async(share)
+        entity = await self.request().update_async(share)
         return entity
 
     @property

--- a/src/python3/request/share_request_builder.py
+++ b/src/python3/request/share_request_builder.py
@@ -65,8 +65,7 @@ class ShareRequestBuilder(RequestBuilderBase):
         """Deletes the specified Share."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Share."""
         yield from self.request().delete_async()
     def get(self):
@@ -78,8 +77,7 @@ class ShareRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Share in async.
 
         Returns:
@@ -101,8 +99,7 @@ class ShareRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(share)
 
-    @asyncio.coroutine
-    def update_async(self, share):
+    async def update_async(self, share):
         """Updates the specified Share in async
         
         Args:

--- a/src/python3/request/shared_collection.py
+++ b/src/python3/request/shared_collection.py
@@ -47,7 +47,7 @@ class SharedCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class SharedCollectionRequestBuilder(RequestBuilderBase):
             :class:`SharedCollectionPage<onedrivesdk.model.shared_collection_page.SharedCollectionPage>`:
                 The SharedCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/shared_collection.py
+++ b/src/python3/request/shared_collection.py
@@ -38,8 +38,7 @@ class SharedCollectionRequest(CollectionRequestBase):
         collection_response = SharedCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SharedCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class SharedCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SharedCollectionPage in async
 
         Yields: 

--- a/src/python3/request/shares_collection.py
+++ b/src/python3/request/shares_collection.py
@@ -38,8 +38,7 @@ class SharesCollectionRequest(CollectionRequestBase):
         collection_response = SharesCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SharesCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class SharesCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SharesCollectionPage in async
 
         Yields: 

--- a/src/python3/request/shares_collection.py
+++ b/src/python3/request/shares_collection.py
@@ -47,7 +47,7 @@ class SharesCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class SharesCollectionRequestBuilder(RequestBuilderBase):
             :class:`SharesCollectionPage<onedrivesdk.model.shares_collection_page.SharesCollectionPage>`:
                 The SharesCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/special_collection.py
+++ b/src/python3/request/special_collection.py
@@ -47,7 +47,7 @@ class SpecialCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class SpecialCollectionRequestBuilder(RequestBuilderBase):
             :class:`SpecialCollectionPage<onedrivesdk.model.special_collection_page.SpecialCollectionPage>`:
                 The SpecialCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/special_collection.py
+++ b/src/python3/request/special_collection.py
@@ -38,8 +38,7 @@ class SpecialCollectionRequest(CollectionRequestBase):
         collection_response = SpecialCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SpecialCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class SpecialCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SpecialCollectionPage in async
 
         Yields: 

--- a/src/python3/request/subscription_request.py
+++ b/src/python3/request/subscription_request.py
@@ -31,8 +31,7 @@ class SubscriptionRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Subscription."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class SubscriptionRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Subscription in async.
 
         Yields:
@@ -80,8 +78,7 @@ class SubscriptionRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, subscription):
+    async def update_async(self, subscription):
         """Updates the specified Subscription in async
         
         Args:

--- a/src/python3/request/subscription_request.py
+++ b/src/python3/request/subscription_request.py
@@ -35,7 +35,7 @@ class SubscriptionRequest(RequestBase):
         """Deletes the specified Subscription."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified Subscription.
@@ -58,7 +58,7 @@ class SubscriptionRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, subscription):
@@ -92,6 +92,6 @@ class SubscriptionRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     subscription)
-        entity = yield from future
+        entity = await future
         return entity
 

--- a/src/python3/request/subscription_request_builder.py
+++ b/src/python3/request/subscription_request_builder.py
@@ -47,8 +47,7 @@ class SubscriptionRequestBuilder(RequestBuilderBase):
         """Deletes the specified Subscription."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Subscription."""
         yield from self.request().delete_async()
     def get(self):
@@ -60,8 +59,7 @@ class SubscriptionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Subscription in async.
 
         Returns:
@@ -83,8 +81,7 @@ class SubscriptionRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(subscription)
 
-    @asyncio.coroutine
-    def update_async(self, subscription):
+    async def update_async(self, subscription):
         """Updates the specified Subscription in async
         
         Args:

--- a/src/python3/request/subscription_request_builder.py
+++ b/src/python3/request/subscription_request_builder.py
@@ -49,7 +49,7 @@ class SubscriptionRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified Subscription."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified Subscription.
         
@@ -66,7 +66,7 @@ class SubscriptionRequestBuilder(RequestBuilderBase):
             :class:`Subscription<onedrivesdk.model.subscription.Subscription>`:
                 The Subscription.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, subscription):
         """Updates the specified Subscription.
@@ -92,5 +92,5 @@ class SubscriptionRequestBuilder(RequestBuilderBase):
             :class:`Subscription<onedrivesdk.model.subscription.Subscription>`:
                 The updated Subscription.
         """
-        entity = yield from self.request().update_async(subscription)
+        entity = await self.request().update_async(subscription)
         return entity

--- a/src/python3/request/subscriptions_collection.py
+++ b/src/python3/request/subscriptions_collection.py
@@ -38,8 +38,7 @@ class SubscriptionsCollectionRequest(CollectionRequestBase):
         collection_response = SubscriptionsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SubscriptionsCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class SubscriptionsCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the SubscriptionsCollectionPage in async
 
         Yields: 

--- a/src/python3/request/subscriptions_collection.py
+++ b/src/python3/request/subscriptions_collection.py
@@ -47,7 +47,7 @@ class SubscriptionsCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class SubscriptionsCollectionRequestBuilder(RequestBuilderBase):
             :class:`SubscriptionsCollectionPage<onedrivesdk.model.subscriptions_collection_page.SubscriptionsCollectionPage>`:
                 The SubscriptionsCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/tag_request.py
+++ b/src/python3/request/tag_request.py
@@ -31,8 +31,7 @@ class TagRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Tag."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class TagRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Tag in async.
 
         Yields:
@@ -80,8 +78,7 @@ class TagRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, tag):
+    async def update_async(self, tag):
         """Updates the specified Tag in async
         
         Args:

--- a/src/python3/request/tag_request.py
+++ b/src/python3/request/tag_request.py
@@ -35,7 +35,7 @@ class TagRequest(RequestBase):
         """Deletes the specified Tag."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified Tag.
@@ -58,7 +58,7 @@ class TagRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, tag):
@@ -92,6 +92,6 @@ class TagRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     tag)
-        entity = yield from future
+        entity = await future
         return entity
 

--- a/src/python3/request/tag_request_builder.py
+++ b/src/python3/request/tag_request_builder.py
@@ -49,7 +49,7 @@ class TagRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified Tag."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified Tag.
         
@@ -66,7 +66,7 @@ class TagRequestBuilder(RequestBuilderBase):
             :class:`Tag<onedrivesdk.model.tag.Tag>`:
                 The Tag.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, tag):
         """Updates the specified Tag.
@@ -92,5 +92,5 @@ class TagRequestBuilder(RequestBuilderBase):
             :class:`Tag<onedrivesdk.model.tag.Tag>`:
                 The updated Tag.
         """
-        entity = yield from self.request().update_async(tag)
+        entity = await self.request().update_async(tag)
         return entity

--- a/src/python3/request/tag_request_builder.py
+++ b/src/python3/request/tag_request_builder.py
@@ -47,8 +47,7 @@ class TagRequestBuilder(RequestBuilderBase):
         """Deletes the specified Tag."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Tag."""
         yield from self.request().delete_async()
     def get(self):
@@ -60,8 +59,7 @@ class TagRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Tag in async.
 
         Returns:
@@ -83,8 +81,7 @@ class TagRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(tag)
 
-    @asyncio.coroutine
-    def update_async(self, tag):
+    async def update_async(self, tag):
         """Updates the specified Tag in async
         
         Args:

--- a/src/python3/request/tags_collection.py
+++ b/src/python3/request/tags_collection.py
@@ -38,8 +38,7 @@ class TagsCollectionRequest(CollectionRequestBase):
         collection_response = TagsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the TagsCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class TagsCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the TagsCollectionPage in async
 
         Yields: 

--- a/src/python3/request/tags_collection.py
+++ b/src/python3/request/tags_collection.py
@@ -47,7 +47,7 @@ class TagsCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class TagsCollectionRequestBuilder(RequestBuilderBase):
             :class:`TagsCollectionPage<onedrivesdk.model.tags_collection_page.TagsCollectionPage>`:
                 The TagsCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/thumbnail_content_request.py
+++ b/src/python3/request/thumbnail_content_request.py
@@ -64,7 +64,7 @@ class ThumbnailContentRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.download,
                                                     content_local_path)
-        yield from future
+        await future
 
 class ThumbnailContentRequestBuilder(RequestBuilderBase):
 

--- a/src/python3/request/thumbnail_content_request.py
+++ b/src/python3/request/thumbnail_content_request.py
@@ -53,8 +53,7 @@ class ThumbnailContentRequest(RequestBase):
         """
         self.download_item(content_local_path)
 
-    @asyncio.coroutine
-    def download_async(self, content_local_path):
+    async def download_async(self, content_local_path):
         """
         Downloads the specified Thumbnail in async.
         

--- a/src/python3/request/thumbnail_request.py
+++ b/src/python3/request/thumbnail_request.py
@@ -31,8 +31,7 @@ class ThumbnailRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Thumbnail."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class ThumbnailRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Thumbnail in async.
 
         Yields:
@@ -80,8 +78,7 @@ class ThumbnailRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, thumbnail):
+    async def update_async(self, thumbnail):
         """Updates the specified Thumbnail in async
         
         Args:

--- a/src/python3/request/thumbnail_request.py
+++ b/src/python3/request/thumbnail_request.py
@@ -35,7 +35,7 @@ class ThumbnailRequest(RequestBase):
         """Deletes the specified Thumbnail."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified Thumbnail.
@@ -58,7 +58,7 @@ class ThumbnailRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, thumbnail):
@@ -92,6 +92,6 @@ class ThumbnailRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     thumbnail)
-        entity = yield from future
+        entity = await future
         return entity
 

--- a/src/python3/request/thumbnail_request_builder.py
+++ b/src/python3/request/thumbnail_request_builder.py
@@ -68,7 +68,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified Thumbnail."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified Thumbnail.
         
@@ -85,7 +85,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
             :class:`Thumbnail<onedrivesdk.model.thumbnail.Thumbnail>`:
                 The Thumbnail.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, thumbnail):
         """Updates the specified Thumbnail.
@@ -111,7 +111,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
             :class:`Thumbnail<onedrivesdk.model.thumbnail.Thumbnail>`:
                 The updated Thumbnail.
         """
-        entity = yield from self.request().update_async(thumbnail)
+        entity = await self.request().update_async(thumbnail)
         return entity
 
     def download(self, local_path):
@@ -130,7 +130,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
             local_path (str): The path where the entity should be
                 downloaded to
         """
-        entity = yield from self.content.request().download_async(local_path)
+        entity = await self.content.request().download_async(local_path)
         return entity
 
     @property

--- a/src/python3/request/thumbnail_request_builder.py
+++ b/src/python3/request/thumbnail_request_builder.py
@@ -66,8 +66,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
         """Deletes the specified Thumbnail."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified Thumbnail."""
         yield from self.request().delete_async()
     def get(self):
@@ -79,8 +78,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified Thumbnail in async.
 
         Returns:
@@ -102,8 +100,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(thumbnail)
 
-    @asyncio.coroutine
-    def update_async(self, thumbnail):
+    async def update_async(self, thumbnail):
         """Updates the specified Thumbnail in async
         
         Args:
@@ -126,8 +123,7 @@ class ThumbnailRequestBuilder(RequestBuilderBase):
         """
         return self.content.request().download(local_path)
 
-    @asyncio.coroutine
-    def download_async(self, local_path):
+    async def download_async(self, local_path):
         """Downloads the specified entity in async.
 
         Args:

--- a/src/python3/request/thumbnail_set_request.py
+++ b/src/python3/request/thumbnail_set_request.py
@@ -31,8 +31,7 @@ class ThumbnailSetRequest(RequestBase):
         self.method = "DELETE"
         self.send()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified ThumbnailSet."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
@@ -50,8 +49,7 @@ class ThumbnailSetRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified ThumbnailSet in async.
 
         Yields:
@@ -80,8 +78,7 @@ class ThumbnailSetRequest(RequestBase):
         self._initialize_collection_properties(entity)
         return entity
 
-    @asyncio.coroutine
-    def update_async(self, thumbnail_set):
+    async def update_async(self, thumbnail_set):
         """Updates the specified ThumbnailSet in async
         
         Args:

--- a/src/python3/request/thumbnail_set_request.py
+++ b/src/python3/request/thumbnail_set_request.py
@@ -35,7 +35,7 @@ class ThumbnailSetRequest(RequestBase):
         """Deletes the specified ThumbnailSet."""
         future = self._client._loop.run_in_executor(None,
                                                     self.delete)
-        yield from future
+        await future
 
     def get(self):
         """Gets the specified ThumbnailSet.
@@ -58,7 +58,7 @@ class ThumbnailSetRequest(RequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        entity = yield from future
+        entity = await future
         return entity
 
     def update(self, thumbnail_set):
@@ -92,6 +92,6 @@ class ThumbnailSetRequest(RequestBase):
         future = self._client._loop.run_in_executor(None,
                                                     self.update,
                                                     thumbnail_set)
-        entity = yield from future
+        entity = await future
         return entity
 

--- a/src/python3/request/thumbnail_set_request_builder.py
+++ b/src/python3/request/thumbnail_set_request_builder.py
@@ -68,7 +68,7 @@ class ThumbnailSetRequestBuilder(RequestBuilderBase):
 
     async def delete_async(self):
         """Deletes the specified ThumbnailSet."""
-        yield from self.request().delete_async()
+        await self.request().delete_async()
     def get(self):
         """Gets the specified ThumbnailSet.
         
@@ -85,7 +85,7 @@ class ThumbnailSetRequestBuilder(RequestBuilderBase):
             :class:`ThumbnailSet<onedrivesdk.model.thumbnail_set.ThumbnailSet>`:
                 The ThumbnailSet.
         """
-        entity = yield from self.request().get_async()
+        entity = await self.request().get_async()
         return entity
     def update(self, thumbnail_set):
         """Updates the specified ThumbnailSet.
@@ -111,7 +111,7 @@ class ThumbnailSetRequestBuilder(RequestBuilderBase):
             :class:`ThumbnailSet<onedrivesdk.model.thumbnail_set.ThumbnailSet>`:
                 The updated ThumbnailSet.
         """
-        entity = yield from self.request().update_async(thumbnail_set)
+        entity = await self.request().update_async(thumbnail_set)
         return entity
 
     @property

--- a/src/python3/request/thumbnail_set_request_builder.py
+++ b/src/python3/request/thumbnail_set_request_builder.py
@@ -66,8 +66,7 @@ class ThumbnailSetRequestBuilder(RequestBuilderBase):
         """Deletes the specified ThumbnailSet."""
         self.request().delete()
 
-    @asyncio.coroutine
-    def delete_async(self):
+    async def delete_async(self):
         """Deletes the specified ThumbnailSet."""
         yield from self.request().delete_async()
     def get(self):
@@ -79,8 +78,7 @@ class ThumbnailSetRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the specified ThumbnailSet in async.
 
         Returns:
@@ -102,8 +100,7 @@ class ThumbnailSetRequestBuilder(RequestBuilderBase):
         """
         return self.request().update(thumbnail_set)
 
-    @asyncio.coroutine
-    def update_async(self, thumbnail_set):
+    async def update_async(self, thumbnail_set):
         """Updates the specified ThumbnailSet in async
         
         Args:

--- a/src/python3/request/thumbnails_collection.py
+++ b/src/python3/request/thumbnails_collection.py
@@ -38,8 +38,7 @@ class ThumbnailsCollectionRequest(CollectionRequestBase):
         collection_response = ThumbnailsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the ThumbnailsCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class ThumbnailsCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the ThumbnailsCollectionPage in async
 
         Yields: 

--- a/src/python3/request/thumbnails_collection.py
+++ b/src/python3/request/thumbnails_collection.py
@@ -47,7 +47,7 @@ class ThumbnailsCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class ThumbnailsCollectionRequestBuilder(RequestBuilderBase):
             :class:`ThumbnailsCollectionPage<onedrivesdk.model.thumbnails_collection_page.ThumbnailsCollectionPage>`:
                 The ThumbnailsCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/versions_collection.py
+++ b/src/python3/request/versions_collection.py
@@ -47,7 +47,7 @@ class VersionsCollectionRequest(CollectionRequestBase):
         """
         future = self._client._loop.run_in_executor(None,
                                                     self.get)
-        collection_page = yield from future
+        collection_page = await future
         return collection_page
 
     @staticmethod
@@ -123,7 +123,7 @@ class VersionsCollectionRequestBuilder(RequestBuilderBase):
             :class:`VersionsCollectionPage<onedrivesdk.model.versions_collection_page.VersionsCollectionPage>`:
                 The VersionsCollectionPage
         """
-        collection_page = yield from self.request().get_async()
+        collection_page = await self.request().get_async()
         return collection_page
 
 

--- a/src/python3/request/versions_collection.py
+++ b/src/python3/request/versions_collection.py
@@ -38,8 +38,7 @@ class VersionsCollectionRequest(CollectionRequestBase):
         collection_response = VersionsCollectionResponse(json.loads(self.send().content))
         return self._page_from_response(collection_response)
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the VersionsCollectionPage in async
 
         Yields: 
@@ -117,8 +116,7 @@ class VersionsCollectionRequestBuilder(RequestBuilderBase):
         """
         return self.request().get()
 
-    @asyncio.coroutine
-    def get_async(self):
+    async def get_async(self):
         """Gets the VersionsCollectionPage in async
 
         Yields: 


### PR DESCRIPTION
Recently TrueNAS Scale upgraded their Python version to 3.11, but `onedrivesdk` in this repo does not work under which. 

This PR solved the problem by using the new `async/await` mechanism instead of `@asyncio.coroutine` and `yield from`.